### PR TITLE
Fix import for React Native v0.40

### DIFF
--- a/ios/SplashScreen.h
+++ b/ios/SplashScreen.h
@@ -6,7 +6,7 @@
 //  Eamil:crazycodeboy@gmail.com
 
 
-#import "RCTBridgeModule.h"
+#import <React/RCTBridge.h>
 
 @interface SplashScreen : NSObject<RCTBridgeModule>
 + (void)show;


### PR DESCRIPTION
See breaking changes: https://github.com/facebook/react-native/releases/tag/v0.40.0.

There's still an error where Xcode can't find the `SplashScreen.h` file when this lib is removed from an app's `HEADER_SEARCH_PATHS`. I'm not sure what's going on there, but it's likely similar to https://github.com/Microsoft/react-native-code-push/issues/662.

After this change, everything works with React Native `v0.40` as long as you keep the `HEADER_SEARCH_PATHS`.