### PR TITLE
Hide screen when a js loading error occurs

### DIFF
--- a/ios/SplashScreen.h
+++ b/ios/SplashScreen.h
@@ -7,7 +7,6 @@
  * Email:crazycodeboy@gmail.com
  */
 #import <React/RCTBridgeModule.h>
-//#import "RCTBridgeModule.h"
 
 @interface SplashScreen : NSObject<RCTBridgeModule>
 + (void)show;

--- a/ios/SplashScreen.h
+++ b/ios/SplashScreen.h
@@ -11,4 +11,5 @@
 
 @interface SplashScreen : NSObject<RCTBridgeModule>
 + (void)show;
++ (void)hide;
 @end

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-splash-screen",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "A splash screen for react-native, hide when application loaded ,it works on iOS and Android.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Hello, thanks for the great package @crazycodeboy.  I found a problem where the splash screen would prevent the red error screen from showing.  This happened when there were certain javascript errors, such as a missing import.  Instead of showing the big red error screen when the app loads, the loading screen would show forever.

This is because the javascript that hides the loading screen never gets called.  To fix that, I handled the iOS React Native notification for when javascript loading fails and hid the screen.  Also, I added a hide method to SplashScreen in case apps want to hide the screen in Objective C and not just Javascript.

This should save some developers plenty of heartache because they'll think the app is hanging when really there is just a javascript problem.  It was only implemented on iOS.  I haven't tested the situation with Android yet, but having only one platform support it is fine.  Thank you!