### PR TITLE
Remove createJSModules - RN 0.47 compatibility

### DIFF
--- a/android/src/main/java/com/cboy/rn/splashscreen/SplashScreenReactPackage.java
+++ b/android/src/main/java/com/cboy/rn/splashscreen/SplashScreenReactPackage.java
@@ -20,11 +20,6 @@ import java.util.List;
 public class SplashScreenReactPackage implements ReactPackage {
 
     @Override
-    public List<Class<? extends JavaScriptModule>> createJSModules() {
-        return Collections.emptyList();
-    }
-
-    @Override
     public List<ViewManager> createViewManagers(ReactApplicationContext reactContext) {
         return Collections.emptyList();
     }

--- a/android/src/main/java/com/cboy/rn/splashscreen/SplashScreenReactPackage.java
+++ b/android/src/main/java/com/cboy/rn/splashscreen/SplashScreenReactPackage.java
@@ -20,8 +20,8 @@ import java.util.List;
 public class SplashScreenReactPackage implements ReactPackage {
 
     // Deprecated RN 0.47
-    public List<Class<? extends JavaScriptModule>> createJSModules() {		
-        return Collections.emptyList();		
+    public List<Class<? extends JavaScriptModule>> createJSModules() {
+        return Collections.emptyList();
     }
 
     @Override

--- a/android/src/main/java/com/cboy/rn/splashscreen/SplashScreenReactPackage.java
+++ b/android/src/main/java/com/cboy/rn/splashscreen/SplashScreenReactPackage.java
@@ -19,7 +19,7 @@ import java.util.List;
  */
 public class SplashScreenReactPackage implements ReactPackage {
 
-    // Depreciated RN 0.47
+    // Deprecated RN 0.47
     public List<Class<? extends JavaScriptModule>> createJSModules() {
         return Collections.emptyList();
     }

--- a/android/src/main/java/com/cboy/rn/splashscreen/SplashScreenReactPackage.java
+++ b/android/src/main/java/com/cboy/rn/splashscreen/SplashScreenReactPackage.java
@@ -19,7 +19,7 @@ import java.util.List;
  */
 public class SplashScreenReactPackage implements ReactPackage {
 
-    // Deprecated RN 0.47
+    // Depreciated RN 0.47
     public List<Class<? extends JavaScriptModule>> createJSModules() {
         return Collections.emptyList();
     }

--- a/android/src/main/java/com/cboy/rn/splashscreen/SplashScreenReactPackage.java
+++ b/android/src/main/java/com/cboy/rn/splashscreen/SplashScreenReactPackage.java
@@ -19,6 +19,7 @@ import java.util.List;
  */
 public class SplashScreenReactPackage implements ReactPackage {
     
+    // Deprecated RN 0.47
     public List<Class<? extends JavaScriptModule>> createJSModules() {		
         return Collections.emptyList();		
     }

--- a/android/src/main/java/com/cboy/rn/splashscreen/SplashScreenReactPackage.java
+++ b/android/src/main/java/com/cboy/rn/splashscreen/SplashScreenReactPackage.java
@@ -18,6 +18,10 @@ import java.util.List;
  * Email:crazycodeboy@gmail.com
  */
 public class SplashScreenReactPackage implements ReactPackage {
+    
+    public List<Class<? extends JavaScriptModule>> createJSModules() {		
+        return Collections.emptyList();		
+    }
 
     @Override
     public List<ViewManager> createViewManagers(ReactApplicationContext reactContext) {

--- a/android/src/main/java/com/cboy/rn/splashscreen/SplashScreenReactPackage.java
+++ b/android/src/main/java/com/cboy/rn/splashscreen/SplashScreenReactPackage.java
@@ -18,7 +18,7 @@ import java.util.List;
  * Email:crazycodeboy@gmail.com
  */
 public class SplashScreenReactPackage implements ReactPackage {
-    
+
     // Deprecated RN 0.47
     public List<Class<? extends JavaScriptModule>> createJSModules() {		
         return Collections.emptyList();		


### PR DESCRIPTION
[`createJSModules` is now not required on Android](https://github.com/facebook/react-native/commit/ce6fb337a146e6f261f2afb564aa19363774a7a8) from RN 0.47. I actually can't build an app on RN 0.47 without removing this method. This is backwards compatible according to my tests.