### PR TITLE
fix typescript definition

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,3 @@
 declare module "react-native-splash-screen" {
-    export default class SplashScreen {
-        static hide(): void;
-    }
+    export function hide(): void;
 }


### PR DESCRIPTION
index.js uses `module.exports` while type definition used `export default`