### PR TITLE
use export default

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,5 +10,5 @@
 'use strict';
 
 import { NativeModules } from 'react-native';
-module.exports = NativeModules.SplashScreen;
+export default NativeModules.SplashScreen;
 


### PR DESCRIPTION
`module.exports` doesn't work with typescript with `import SplashScreen from 'react-native-splash-screen'`
`export default` works and it also matches type definition

fixes https://github.com/crazycodeboy/react-native-splash-screen/issues/100