### PR TITLE
Optional theming to Android splash screen

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ public class MainApplication extends Application implements ReactApplication {
 2. Go to `node_modules` ➜ `react-native-splash-screen` and add `SplashScreen.xcodeproj`
 3. In XCode, in the project navigator, select your project. Add `libSplashScreen.a` to your project's `Build Phases` ➜ `Link Binary With Libraries`
 4. To fix `'SplashScreen.h' file not found`, you have to select your project → Build Settings → Search Paths → Header Search Paths to add:
-   
+
    `$(SRCROOT)/../node_modules/react-native-splash-screen/ios`
 
 
@@ -203,12 +203,27 @@ Open `android/app/src/main/res/values/styles.xml` and add `<item name="android:w
 
 If you want to customize the color of the status bar when the splash screen is displayed:
 
-Create `android/app/src/main/res/values/colors.xml` and add 
+Create `android/app/src/main/res/values/colors.xml` and add
 ```xml
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <color name="primary_dark"><!-- Colour of your status bar here --></color>
+    <color name="status_bar_color"><!-- Colour of your status bar here --></color>
 </resources>
+```
+
+Create a style definition for this in `android/app/src/main/res/values/colors.xml`:
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <style name="SplashScreenTheme" parent="SplashScreen_SplashTheme">
+        <item name="colorPrimaryDark">@color/status_bar_color</item>
+    </style>
+</resources>
+```
+
+Change your `show` method to include your custom style:
+```java
+SplashScreen.show(this, false, R.style.SplashScreenTheme);
 ```
 
 ### iOS    

--- a/android/src/main/java/org/devio/rn/splashscreen/SplashScreen.java
+++ b/android/src/main/java/org/devio/rn/splashscreen/SplashScreen.java
@@ -14,13 +14,14 @@ import java.lang.ref.WeakReference;
  * Email:crazycodeboy@gmail.com
  */
 public class SplashScreen {
+    private static int NULL_ID = 0;
     private static Dialog mSplashDialog;
     private static WeakReference<Activity> mActivity;
 
     /**
      * 打开启动屏
      */
-    public static void show(final Activity activity, final boolean fullScreen) {
+    public static void show(final Activity activity, final boolean fullScreen, final int themeResId) {
         if (activity == null) return;
         mActivity = new WeakReference<Activity>(activity);
         activity.runOnUiThread(new Runnable() {
@@ -28,7 +29,12 @@ public class SplashScreen {
             public void run() {
                 if (!activity.isFinishing()) {
 
-                    mSplashDialog = new Dialog(activity, fullScreen ? R.style.SplashScreen_Fullscreen : R.style.SplashScreen_SplashTheme);
+                    mSplashDialog = new Dialog(
+                            activity,
+                            themeResId != NULL_ID ? themeResId
+                                    : fullScreen ? R.style.SplashScreen_Fullscreen
+                                    : R.style.SplashScreen_SplashTheme
+                    );
                     mSplashDialog.setContentView(R.layout.launch_screen);
                     mSplashDialog.setCancelable(false);
 
@@ -38,6 +44,13 @@ public class SplashScreen {
                 }
             }
         });
+    }
+
+    /**
+     * 打开启动屏
+     */
+    public static void show(final Activity activity, final boolean fullScreen) {
+        show(activity, fullScreen, 0);
     }
 
     /**

--- a/android/src/main/res/values/refs.xml
+++ b/android/src/main/res/values/refs.xml
@@ -3,7 +3,4 @@
     <item type="layout" name="launch_screen">
         @layout/launch_screen
     </item>
-    <item type="color" name="primary_dark">
-        @color/primary_dark
-    </item>
 </resources>

--- a/android/src/main/res/values/styles.xml
+++ b/android/src/main/res/values/styles.xml
@@ -5,7 +5,6 @@
 
     <style name="SplashScreen_SplashTheme" parent="Theme.AppCompat.NoActionBar">
         <item name="android:windowAnimationStyle">@style/SplashScreen_SplashAnimation</item>
-        <item name="colorPrimaryDark">@color/primary_dark</item>
     </style>
     <style name="SplashScreen_Fullscreen" parent="SplashScreen_SplashTheme">
         <item name="android:windowFullscreen">true</item>


### PR DESCRIPTION
#102 had introduced a breaking change, where builds would fail if you didn't add a style definition for the status bar color.

This PR reverts those changes but introduces an alternative, backward-compatible method of setting custom status bar colors through theming. I've overloaded the `show` method, so you can choose to optionally include a style, or not include a style at all.

If you wanted to change the status bar color to a color `primary_dark ` in your `colors.xml` file, you'd create a style definition in your app, presumably in `styles.xml`:
```java
<style name="SplashScreenTheme" parent="SplashScreen_SplashTheme">
    <item name="colorPrimaryDark">@color/primary_dark</item>
</style>
```

Then you'd include this theme when showing the splash screen:
```java
SplashScreen.show(this, false, R.style.SplashScreenTheme);
```

## Related issues
Closes #123 
