### PR TITLE
Destroyed/finishing activity check on hide

### DIFF
--- a/android/src/main/java/org/devio/rn/splashscreen/SplashScreen.java
+++ b/android/src/main/java/org/devio/rn/splashscreen/SplashScreen.java
@@ -78,14 +78,14 @@ public class SplashScreen {
         _activity.runOnUiThread(new Runnable() {
             @Override
             public void run() {
-                if (mSplashDialog != null && mSplashDialog.isShowing() && !_activity.isFinishing()) {
+                if (mSplashDialog != null && mSplashDialog.isShowing()) {
                     boolean isDestroyed = false;
 
                     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
                         isDestroyed = _activity.isDestroyed();
                     }
 
-                    if (!isDestroyed) {
+                    if (!_activity.isFinishing() && !isDestroyed) {
                         mSplashDialog.dismiss();
                     }
                     mSplashDialog = null;

--- a/android/src/main/java/org/devio/rn/splashscreen/SplashScreen.java
+++ b/android/src/main/java/org/devio/rn/splashscreen/SplashScreen.java
@@ -2,6 +2,7 @@ package org.devio.rn.splashscreen;
 
 import android.app.Activity;
 import android.app.Dialog;
+import android.os.Build;
 
 import java.lang.ref.WeakReference;
 

--- a/android/src/main/java/org/devio/rn/splashscreen/SplashScreen.java
+++ b/android/src/main/java/org/devio/rn/splashscreen/SplashScreen.java
@@ -70,13 +70,24 @@ public class SplashScreen {
             }
             activity = mActivity.get();
         }
+
         if (activity == null) return;
 
-        activity.runOnUiThread(new Runnable() {
+        final Activity _activity = activity;
+
+        _activity.runOnUiThread(new Runnable() {
             @Override
             public void run() {
-                if (mSplashDialog != null && mSplashDialog.isShowing()) {
-                    mSplashDialog.dismiss();
+                if (mSplashDialog != null && mSplashDialog.isShowing() && !_activity.isFinishing()) {
+                    boolean isDestroyed = false;
+
+                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
+                        isDestroyed = _activity.isDestroyed();
+                    }
+
+                    if (!isDestroyed) {
+                        mSplashDialog.dismiss();
+                    }
                     mSplashDialog = null;
                 }
             }


### PR DESCRIPTION
Hi,

we are getting crashes that dismiss was called on finishing or destroyed activity.

This PR adds check for it before dismissing the splash screen dialog.

I couldn't find for sure that ```isFinishing()``` must return ```true``` when ```isDestroyed()``` is ```true``` so I've added ```isDestroyed()``` check too for API >= 17.