### PR TITLE
Update launch_screen.xml

### DIFF
--- a/examples/android/app/src/main/res/layout/launch_screen.xml
+++ b/examples/android/app/src/main/res/layout/launch_screen.xml
@@ -1,7 +1,18 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:orientation="vertical" android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:background="@drawable/launch_screen">
 
-</LinearLayout>
+ <RelativeLayout 
+  xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="fill_parent"
+    android:layout_height="fill_parent"
+    android:background="@android:color/black">
+
+    <LinearLayout
+        android:layout_width="350dip"
+        android:layout_height="450dip"
+        android:layout_centerInParent="true"
+        android:background="@drawable/launch_screen"
+        android:orientation="vertical"
+        android:padding="30dip"
+        >
+    </LinearLayout>
+ </RelativeLayout>


### PR DESCRIPTION

original code resulted in portrait to landscape rotation splash-screen image distortion. The rotated to landscape view stretched the original background picture

https://github.com/crazycodeboy/react-native-splash-screen/commit/b3840bcda1ccccb6a7bab25a37bce4418c29b964