### PR TITLE
Code cleanup for show method

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ Create a style definition for this in `android/app/src/main/res/values/colors.xm
 
 Change your `show` method to include your custom style:
 ```java
-SplashScreen.show(this, false, R.style.SplashScreenTheme);
+SplashScreen.show(this, R.style.SplashScreenTheme);
 ```
 
 ### iOS    

--- a/android/src/main/java/org/devio/rn/splashscreen/SplashScreen.java
+++ b/android/src/main/java/org/devio/rn/splashscreen/SplashScreen.java
@@ -14,27 +14,20 @@ import java.lang.ref.WeakReference;
  * Email:crazycodeboy@gmail.com
  */
 public class SplashScreen {
-    private static int NULL_ID = 0;
     private static Dialog mSplashDialog;
     private static WeakReference<Activity> mActivity;
 
     /**
      * 打开启动屏
      */
-    public static void show(final Activity activity, final boolean fullScreen, final int themeResId) {
+    public static void show(final Activity activity, final int themeResId) {
         if (activity == null) return;
         mActivity = new WeakReference<Activity>(activity);
         activity.runOnUiThread(new Runnable() {
             @Override
             public void run() {
                 if (!activity.isFinishing()) {
-
-                    mSplashDialog = new Dialog(
-                            activity,
-                            themeResId != NULL_ID ? themeResId
-                                    : fullScreen ? R.style.SplashScreen_Fullscreen
-                                    : R.style.SplashScreen_SplashTheme
-                    );
+                    mSplashDialog = new Dialog(activity, themeResId);
                     mSplashDialog.setContentView(R.layout.launch_screen);
                     mSplashDialog.setCancelable(false);
 
@@ -50,7 +43,9 @@ public class SplashScreen {
      * 打开启动屏
      */
     public static void show(final Activity activity, final boolean fullScreen) {
-        show(activity, fullScreen, 0);
+        int resourceId = fullScreen ? R.style.SplashScreen_Fullscreen : R.style.SplashScreen_SplashTheme;
+
+        show(activity, resourceId);
     }
 
     /**


### PR DESCRIPTION
Following up from my [comment](https://github.com/crazycodeboy/react-native-splash-screen/pull/125/files#r152034237) in #125.

This simplifies the public interface for showing the splash screen with a custom theme:
```java
// Show with a custom theme
SplashScreen.show(this, R.style.SplashScreenTheme);

// Show with the default theme
SplashScreen.show(this);
// or alternatively
SplashScreen.show(this, false);

// Show with the default fullscreen theme
SplashScreen.show(this, true);
```



**As a secondary request, could you push a new release version after merge?**
After #125 was merged, there is no release containing the new fixes.