### PR TITLE
Remove allowBackup & supportsRtl from AndroidManifest

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -2,9 +2,7 @@
     package="org.devio.rn.splashscreen">
 
     <application
-        android:allowBackup="true"
-        android:label="@string/app_name"
-        android:supportsRtl="true">
+        android:label="@string/app_name">
 
     </application>
 


### PR DESCRIPTION
RN 0.54 changes the `AndroidManifest.xml` setting for `android:allowBackup` from `true` to `false`: https://github.com/facebook/react-native/commit/d7a9ca2

As react-native-splash-screen specifies `android:allowBackup="true"`, this causes the following linker error for all new RN projects (and those that specify: `android:allowBackup="false"`)

```
Attribute application@allowBackup value=(false) from AndroidManifest.xml
is also present at [react-native-splash-screen] AndroidManifest.xml value=(true).

Suggestion: add 'tools:replace="android:allowBackup"' to <application> 
element at AndroidManifest.xml

BUILD FAILED
```


This PR removes this default from the library, along with the default for `android:supportsRtl`, as per this suggestion: https://medium.com/@elye.project/2-lines-in-manifest-to-remove-when-sharing-your-android-library-565d4c4af04a