### PR TITLE
Fix gradle lint errors

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -21,6 +21,6 @@ android {
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     testCompile 'junit:junit:4.12'
-    compile 'com.android.support:appcompat-v7:23.4.0'
+    compile 'com.android.support:appcompat-v7:25.4.0'
     compile "com.facebook.react:react-native:+"  // From node_modules
 }


### PR DESCRIPTION
Gradle lint gives a hard error if the major versions mismatch
"This support library should not use a different version (23) than the compileSdkVersion (25)"