### PR TITLE
Update Header Search Path to also point to Cocoapods headers

### DIFF
--- a/ios/SplashScreen.xcodeproj/project.pbxproj
+++ b/ios/SplashScreen.xcodeproj/project.pbxproj
@@ -205,7 +205,7 @@
 		3D7682801D8E76B80014119E /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				HEADER_SEARCH_PATHS = "";
+				HEADER_SEARCH_PATHS = "${SRCROOT}/../../../ios/Pods/Headers/Public/**";
 				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -216,7 +216,7 @@
 		3D7682811D8E76B80014119E /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				HEADER_SEARCH_PATHS = "";
+				HEADER_SEARCH_PATHS = "${SRCROOT}/../../../ios/Pods/Headers/Public/**";
 				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = "$(TARGET_NAME)";


### PR DESCRIPTION
This pull request updates the HEADER_SEARCH_PATHS Xcode build setting to include the Cocoapods headers path.