### PR TITLE
getUseDeveloperSupport is now public

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ public class MainApplication extends Application implements ReactApplication {
 
     private final ReactNativeHost mReactNativeHost = new ReactNativeHost(this) {
         @Override
-        protected boolean getUseDeveloperSupport() {
+        public boolean getUseDeveloperSupport() {
             return BuildConfig.DEBUG;
         }
 


### PR DESCRIPTION
A breaking change made `getUseDeveloperSupport` public https://github.com/facebook/react-native/pull/11329