### PR TITLE
Update deprecated build.gradle

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -19,8 +19,8 @@ android {
 }
 
 dependencies {
-    implementation fileTree(dir: 'libs', include: ['*.jar'])
-    testImplementation 'junit:junit:4.12'
-    implementation 'com.android.support:appcompat-v7:27.0.2'
-    implementation "com.facebook.react:react-native:+"  // From node_modules
+    compile fileTree(dir: 'libs', include: ['*.jar'])
+    testCompile 'junit:junit:4.12'
+    compile 'com.android.support:appcompat-v7:27.0.2'
+    compile "com.facebook.react:react-native:+"  // From node_modules
 }


### PR DESCRIPTION
I found solution here https://stackoverflow.com/questions/45615474/gradle-error-could-not-find-method-implementation-for-arguments-com-android
Fixing this bug https://github.com/crazycodeboy/react-native-splash-screen/issues/229