### PR TITLE
Expose [Splashscreen show] native method to JS

### DIFF
--- a/ios/SplashScreen.m
+++ b/ios/SplashScreen.m
@@ -48,4 +48,8 @@ RCT_EXPORT_METHOD(hide) {
     [SplashScreen hide];
 }
 
+RCT_EXPORT_METHOD(show) {
+    [SplashScreen show];
+}
+
 @end


### PR DESCRIPTION
We need to be able to invoke `SplashScreen.show()` during in-app deep linking.