### PR TITLE
fix ios splashscreen name

### DIFF
--- a/ios/RNSplashScreen.h
+++ b/ios/RNSplashScreen.h
@@ -8,7 +8,7 @@
  */
 #import <React/RCTBridgeModule.h>
 
-@interface SplashScreen : NSObject<RCTBridgeModule>
+@interface RNSplashScreen : NSObject<RCTBridgeModule>
 + (void)show;
 + (void)hide;
 @end

--- a/ios/RNSplashScreen.m
+++ b/ios/RNSplashScreen.m
@@ -7,17 +7,17 @@
  * Email:crazycodeboy@gmail.com
  */
 
-#import "SplashScreen.h"
+#import "RNSplashScreen.h"
 #import <React/RCTBridge.h>
 
 static bool waiting = true;
 static bool addedJsLoadErrorObserver = false;
 
-@implementation SplashScreen
+@implementation RNSplashScreen
 - (dispatch_queue_t)methodQueue{
     return dispatch_get_main_queue();
 }
-RCT_EXPORT_MODULE()
+RCT_EXPORT_MODULE(SplashScreen)
 
 + (void)show {
     if (!addedJsLoadErrorObserver) {
@@ -41,11 +41,11 @@ RCT_EXPORT_MODULE()
 + (void) jsLoadError:(NSNotification*)notification
 {
     // If there was an error loading javascript, hide the splash screen so it can be shown.  Otherwise the splash screen will remain forever, which is a hassle to debug.
-    [SplashScreen hide];
+    [RNSplashScreen hide];
 }
 
 RCT_EXPORT_METHOD(hide) {
-    [SplashScreen hide];
+    [RNSplashScreen hide];
 }
 
 @end

--- a/ios/SplashScreen.xcodeproj/project.pbxproj
+++ b/ios/SplashScreen.xcodeproj/project.pbxproj
@@ -7,7 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		3D7682841D8E76D10014119E /* SplashScreen.m in Sources */ = {isa = PBXBuildFile; fileRef = 3D7682831D8E76D10014119E /* SplashScreen.m */; };
+		3D7682841D8E76D10014119E /* RNSplashScreen.m in Sources */ = {isa = PBXBuildFile; fileRef = 3D7682831D8E76D10014119E /* RNSplashScreen.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -24,8 +24,8 @@
 
 /* Begin PBXFileReference section */
 		3D7682761D8E76B80014119E /* libSplashScreen.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libSplashScreen.a; sourceTree = BUILT_PRODUCTS_DIR; };
-		3D7682821D8E76D10014119E /* SplashScreen.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SplashScreen.h; sourceTree = "<group>"; };
-		3D7682831D8E76D10014119E /* SplashScreen.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SplashScreen.m; sourceTree = "<group>"; };
+		3D7682821D8E76D10014119E /* RNSplashScreen.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RNSplashScreen.h; sourceTree = "<group>"; };
+		3D7682831D8E76D10014119E /* RNSplashScreen.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RNSplashScreen.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -42,8 +42,8 @@
 		3D76826D1D8E76B80014119E = {
 			isa = PBXGroup;
 			children = (
-				3D7682821D8E76D10014119E /* SplashScreen.h */,
-				3D7682831D8E76D10014119E /* SplashScreen.m */,
+				3D7682821D8E76D10014119E /* RNSplashScreen.h */,
+				3D7682831D8E76D10014119E /* RNSplashScreen.m */,
 				3D7682771D8E76B80014119E /* Products */,
 			);
 			sourceTree = "<group>";
@@ -113,7 +113,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				3D7682841D8E76D10014119E /* SplashScreen.m in Sources */,
+				3D7682841D8E76D10014119E /* RNSplashScreen.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
`SplashScreen.h` 非常容易和第三方项目的命名发生冲突，例如我现在在RN项目中集成了Unity，导出的Unity项目也恰好有一个`SplashScreen.h`的文件，文件命名重复，导致项目编译失败。 建议按照RN的组件规范，加上特定前缀防止该类问题。