### PR TITLE
Upgrade SDK Build Tools for react-native 0.56.0

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,14 +1,16 @@
 apply plugin: 'com.android.library'
 
+def safeExtGet(prop, fallback) {
+    rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
+
 android {
-    compileSdkVersion 23
-    buildToolsVersion "23.0.1"
+    compileSdkVersion safeExtGet('compileSdkVersion', 26)
+    buildToolsVersion safeExtGet('buildToolsVersion', '26.0.3')
 
     defaultConfig {
-        minSdkVersion 16
-        targetSdkVersion 22
-        versionCode 1
-        versionName "1.0"
+        minSdkVersion safeExtGet('minSdkVersion', 16)
+        targetSdkVersion safeExtGet('targetSdkVersion', 26)
     }
     buildTypes {
         release {
@@ -21,6 +23,6 @@ android {
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     testCompile 'junit:junit:4.12'
-    compile 'com.android.support:appcompat-v7:23.0.1'
+    compile "com.android.support:appcompat-v7:${safeExtGet('supportLibVersion', '27.1.0')}"
     compile "com.facebook.react:react-native:+" // From node_modules
 }


### PR DESCRIPTION
Making it compatible with react-native 0.56.0
Fixing #245 

Can use
ext {
buildToolsVersion = "23.0.1"
minSdkVersion = 16
compileSdkVersion = 23
targetSdkVersion = 23
supportLibVersion = "23.0.1"
}
if you are using older tools.