### PR TITLE
Fix for iOS RNSplashScreen show method

### DIFF
--- a/ios/RNSplashScreen.m
+++ b/ios/RNSplashScreen.m
@@ -49,7 +49,7 @@ RCT_EXPORT_METHOD(hide) {
 }
 
 RCT_EXPORT_METHOD(show) {
-    [SplashScreen show];
+    [RNSplashScreen show];
 }
 
 @end

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-splash-screen",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "A splash screen for react-native, hide when application loaded ,it works on iOS and Android.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Currently build fails because of [SplashScreen show] method. Fixed this issue and increased the version so that it can be downloaded again.