### PR TITLE
Update RNSplashScreen.m - Show Method Reference

### DIFF
--- a/ios/RNSplashScreen.m
+++ b/ios/RNSplashScreen.m
@@ -49,7 +49,7 @@ RCT_EXPORT_METHOD(hide) {
 }
 
 RCT_EXPORT_METHOD(show) {
-    [SplashScreen show];
+    [RNSplashScreen show];
 }
 
 @end


### PR DESCRIPTION
The reference to splash screen in the show method didn't match the implementation name. This was causing a failure on the on the show command.