### PR TITLE
Update build.gradle for RN 0.57 compatibility

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,15 +1,24 @@
 apply plugin: 'com.android.library'
 
+def _ext = rootProject.ext
+
+def _reactNativeVersion = _ext.has('reactNative') ? _ext.reactNative : '+'
+def _compileSdkVersion = _ext.has('compileSdkVersion') ? _ext.compileSdkVersion : 27
+def _buildToolsVersion = _ext.has('buildToolsVersion') ? _ext.buildToolsVersion : '27.0.3'
+def _minSdkVersion = _ext.has('minSdkVersion') ? _ext.minSdkVersion : 16
+def _targetSdkVersion = _ext.has('targetSdkVersion') ? _ext.targetSdkVersion : 27
+
 android {
-    compileSdkVersion 26
-    buildToolsVersion "26.0.3"
+    compileSdkVersion _compileSdkVersion
+    buildToolsVersion _buildToolsVersion
 
     defaultConfig {
-        minSdkVersion 16
-        targetSdkVersion 26
+        minSdkVersion _minSdkVersion
+        targetSdkVersion _targetSdkVersion
         versionCode 1
         versionName "1.0"
     }
+    
     buildTypes {
         release {
             minifyEnabled false
@@ -19,8 +28,8 @@ android {
 }
 
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
-    testCompile 'junit:junit:4.12'
-    compile 'com.android.support:appcompat-v7:26.1.0'
-    compile "com.facebook.react:react-native:+" // From node_modules
+    implementation fileTree(dir: 'libs', include: ['*.jar'])
+    testImplementation 'junit:junit:4.12'
+    implementation "com.android.support:appcompat-v7:${_buildToolsVersion}"
+    implementation "com.facebook.react:react-native:${_reactNativeVersion}"
 }


### PR DESCRIPTION
React Native 0.57 will [scaffold new projects using Gradle 3, instead of Gradle 2](https://github.com/facebook/react-native/commit/6eac2d4e2f5f697043b495002872bfac3e8595cb).

Users who install this library with Gradle 3 will see the following error:

```
Configuration 'compile' is obsolete and has been replaced with 'implementation' and 'api'.
It will be removed at the end of 2018. For more information see: http://d.android.com/r/tools/update-dependency-configurations.html
```

This PR fixes this warning.

Please note: this will cause any users who are still on Gradle 2 to see an error:

```
> Could not find method implementation() for arguments [com.facebook.react:react-native:+] on object of type org.gradle.api.internal.artifacts.dsl.dependencies.DefaultDependencyHandler.
```

This is because `implementation` is only available for users of Gradle 3.

It may therefore be worth bumping the major version of this lib to indicate a breaking change for some users.