### PR TITLE
Update build.gradle to remove compile warnings

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -19,8 +19,8 @@ android {
 }
 
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
-    testCompile 'junit:junit:4.12'
-    compile 'com.android.support:appcompat-v7:26.1.0'
-    compile "com.facebook.react:react-native:+" // From node_modules
+    implementation fileTree(dir: 'libs', include: ['*.jar'])
+    testImplementation 'junit:junit:4.12'
+    implementation 'com.android.support:appcompat-v7:26.1.0'
+    implementation "com.facebook.react:react-native:+" // From node_modules
 }


### PR DESCRIPTION
With the latest react-native version RN >= 0.57 the android build tools were updated and now using compile and testCompile in the `build.gradle` file generates the following errors:

> WARNING: Configuration 'compile' is obsolete and has been replaced with 'implementation' and 'api'.
> It will be removed at the end of 2018. For more information see: http://d.android.com/r/tools/update-dependency-configurations.html
> 
> WARNING: Configuration 'testCompile' is obsolete and has been replaced with 'testImplementation' and 'testApi'.
> It will be removed at the end of 2018. For more information see: http://d.android.com/r/tools/update-dependency-configurations.html