### PR TITLE
remove android:label attribute in AndroidManifest.xml

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,9 +1,4 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="org.devio.rn.splashscreen">
 
-    <application
-        android:label="@string/app_name">
-
-    </application>
-
 </manifest>

--- a/android/src/main/res/values/strings.xml
+++ b/android/src/main/res/values/strings.xml
@@ -1,3 +1,2 @@
 <resources>
-    <string name="app_name">SplashScreen</string>
 </resources>


### PR DESCRIPTION
This attribute may cause build problem:
```
Execution failed for task ':app:processReleaseManifest'.
> Manifest merger failed : Attribute application@label value=(@string/APP_NAME) from AndroidManifest.xml:11:9-41
  	is also present at [:react-native-splash-screen] AndroidManifest.xml:11:18-45 value=(strinp_name).
  	Suggestion: add 'tools:replace="android:label"' to <application> element at AndroidManifest.xml:7:5-27:19 to override.
```

I think the best solution is to remove this attribute.