### PR TITLE
更新中文文档

### DIFF
--- a/README.zh.md
+++ b/README.zh.md
@@ -187,6 +187,7 @@ public class MainActivity extends ReactActivity {
     <style name="AppTheme" parent="Theme.AppCompat.Light.NoActionBar">
         <!-- Customize your theme here. -->
         <!--设置透明背景-->
+        <!--当你期望在安卓8.0.0上运行时，设置了此项为true，请检查AndroidManifest.xml文件，当android:screenOrientation="portrait"时会发生崩溃          -->
         + <item name="android:windowIsTranslucent">true</item>
     </style>
 </resources>


### PR DESCRIPTION
## 中文：
1. 安卓平台当SDK小于27且系统版本为8.0.0时，并同时设置了android:screenOrientation="portrait"和<item name="android:windowIsTranslucent">true</item>时，App将不能正常打开，我认为应该告知开发者，避免其他开发者遇到这个问题。
2. 请更新英文文档。
## English：
1. When the SDK is less than 27 and the system version is 8.0.0 on the Android platform, and the android: screenOrientation = "portrait" and <item name = "android: windowIsTranslucent"> true </ item> are set at the same time, the App will not work properly Open, I think developers should be informed to avoid other developers encounter this problem.
2. Please update the English documentation.