### PR TITLE
fix: Xcode 12 compatibility

### DIFF
--- a/react-native-splash-screen.podspec
+++ b/react-native-splash-screen.podspec
@@ -12,5 +12,5 @@ Pod::Spec.new do |s|
   s.platform     = :ios, "7.0"
   s.source       = { :git => "https://github.com/crazycodeboy/react-native-splash-screen", :tag => "v#{s.version}" }
   s.source_files  = "ios/*.{h,m}"
-  s.dependency "React"
+  s.dependency "React-Core"
 end


### PR DESCRIPTION
The latest Xcode 12 fails to build when a module does not depend on `React-Core` directly. This change is necessary for all native modules on iOS. For details please see: https://github.com/facebook/react-native/issues/29633#issuecomment-694187116