### PR TITLE
Bump minSdkVersion up to 21 to be compatible with react native 0.64

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -10,7 +10,7 @@ android {
     buildToolsVersion rootProject.hasProperty('buildToolsVersion') ? rootProject.buildToolsVersion : DEFAULT_BUILD_TOOLS_VERSION
 
     defaultConfig {
-        minSdkVersion 16
+        minSdkVersion 21
         targetSdkVersion rootProject.hasProperty('targetSdkVersion') ? rootProject.targetSdkVersion : DEFAULT_TARGET_SDK_VERSION
         versionCode 1
         versionName "1.0"

--- a/examples/android/build.gradle
+++ b/examples/android/build.gradle
@@ -3,7 +3,7 @@
 buildscript {
     ext {
         buildToolsVersion = "28.0.3"
-        minSdkVersion = 16
+        minSdkVersion = 21
         compileSdkVersion = 28
         targetSdkVersion = 28
     }


### PR DESCRIPTION
One of the features  of React Native [0.64](https://github.com/facebook/react-native/releases):
> Remove support of Android API levels 16 through 20. The new minSDK version will be 21+ moving forward

This results in the following error:
```
> Task :react-native-splash-screen:processDebugAndroidTestManifest FAILED
[androidx.vectordrawable:vectordrawable-animated:1.0.0] /Users/brettnew/.gradle/caches/transforms-2/files-2.1/6bd26608a56471388473668857507fd3/vectordrawable-animated-1.0.0/AndroidManifest.xml Warning:
        Package name 'androidx.vectordrawable' used in: androidx.vectordrawable:vectordrawable-animated:1.0.0, androidx.vectordrawable:vectordrawable:1.0.1.
/Users/brettnew/dev/NCOE-Mobile/node_modules/react-native-splash-screen/android/build/intermediates/tmp/manifest/androidTest/debug/manifestMerger4647942573811944626.xml:5:5-74 Error:
        uses-sdk:minSdkVersion 16 cannot be smaller than version 21 declared in library [com.facebook.react:react-native:0.64.0] /Users/brettnew/.gradle/caches/transforms-2/files-2.1/64f77f7107b06b56dc6f07859388d2ec/jetified-react-native-0.64.0/AndroidManifest.xml as the library might be using APIs not available in 16
        Suggestion: use a compatible library with a minSdk of at most 16,
                or increase this project's minSdk version to at least 21,
                or use tools:overrideLibrary="com.facebook.react" to force usage (may lead to runtime failures)

See http://g.co/androidstudio/manifest-merger for more information about the manifest merger.


FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':react-native-splash-screen:processDebugAndroidTestManifest'.
```
![image](https://user-images.githubusercontent.com/19401267/111509811-1b7d5f00-871b-11eb-82c2-841442650c77.png)


 when trying to run the `assembleAndroidTest` part of the `cd android && ./gradlew assembleDebug assembleAndroidTest -DtestBuildType=debug && cd ..`, a command used by the [detox](https://github.com/wix/Detox/blob/8c7e80ae610364eb811db82611257f1a33eff42f/docs/Introduction.Android.md#2-apply-detox-configuration) testing library.
 
 This PR fixes this error by bumping react-native-splash-screen's minSdkVersion up to 21 to allow this command to continue working.
 
 



