### PR TITLE
Set android sdk version to 21

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -10,7 +10,7 @@ android {
     buildToolsVersion rootProject.hasProperty('buildToolsVersion') ? rootProject.buildToolsVersion : DEFAULT_BUILD_TOOLS_VERSION
 
     defaultConfig {
-        minSdkVersion 16
+        minSdkVersion 21
         targetSdkVersion rootProject.hasProperty('targetSdkVersion') ? rootProject.targetSdkVersion : DEFAULT_TARGET_SDK_VERSION
         versionCode 1
         versionName "1.0"

--- a/examples/android/build.gradle
+++ b/examples/android/build.gradle
@@ -3,7 +3,7 @@
 buildscript {
     ext {
         buildToolsVersion = "28.0.3"
-        minSdkVersion = 16
+        minSdkVersion = 21
         compileSdkVersion = 28
         targetSdkVersion = 28
     }


### PR DESCRIPTION
Hi,
 
React Native 0.64 need a minimum version of 21 for the android Sdk.

Regards,
Nicolas