### PR TITLE
Correct documentation on `show` method

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ Create a style definition for this in `android/app/src/main/res/values/styles.xm
 
 Change your `show` method to include your custom style:
 ```java
-SplashScreen.show(this, R.style.SplashScreenTheme);
+SplashScreen.show(this, R.style.SplashScreenTheme, true);
 ```
 
 ### iOS    
@@ -281,6 +281,7 @@ export default class WelcomePage extends Component {
 |--------|----------|----------|-------------------------------------|
 | show() | function | false    | Open splash screen (Native Method ) |
 | show(final Activity activity, final boolean fullScreen) | function | false    | Open splash screen (Native Method ) |
+| show(final Activity activity, final int themeResId, final boolean fullScreen) | function | false    | Open splash screen with specified theme (Native Method ) |
 | hide() | function | false    | Close splash screen                 |
 
 ## Testing

--- a/README.md
+++ b/README.md
@@ -279,9 +279,9 @@ export default class WelcomePage extends Component {
 
 | Method | Type     | Optional | Description                         |
 |--------|----------|----------|-------------------------------------|
-| show() | function | false    | Open splash screen (Native Method ) |
-| show(final Activity activity, final boolean fullScreen) | function | false    | Open splash screen (Native Method ) |
-| show(final Activity activity, final int themeResId, final boolean fullScreen) | function | false    | Open splash screen with specified theme (Native Method ) |
+| show() | function | false    | Open splash screen (Native Method) |
+| show(final Activity activity, final boolean fullScreen) | function | false    | Open splash screen (Native Method) |
+| show(final Activity activity, final int themeResId, final boolean fullScreen) | function | false    | Open splash screen with specified theme (Native Method) |
 | hide() | function | false    | Close splash screen                 |
 
 ## Testing


### PR DESCRIPTION
Example `show` method is incorrect in repository.  It's missing the boolean `fullScreen` parameter. Also, it isn't documented in the method table below.  This PR adds the `fullScreen` parameter and documents the additional `show` overload in the methods table.

## Changes
* Add `fullScreen` parameter to sample `show` with styles method in README
* Document `show` with styles method in README methods table