### PR TITLE
Fix: junit vulnerability

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -31,7 +31,7 @@ dependencies {
     def supportLibVersion = rootProject.hasProperty('supportLibVersion') ? rootProject.supportLibVersion : DEFAULT_SUPPORT_LIB_VERSION
 
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    testImplementation 'junit:junit:4.12'
+    testImplementation 'junit:junit:4.13.2'
     implementation "com.android.support:appcompat-v7:$supportLibVersion"
     implementation "com.facebook.react:react-native:+" // From node_modules
 }


### PR DESCRIPTION
Information Exposure
junit:junit is an unit testing framework for Java

Affected versions of this package are vulnerable to Information Exposure. The JUnit4 test rule TemporaryFolder contains a local information disclosure vulnerability. On Unix like systems, the system's temporary directory is shared between all users on that system. Because of this, when files and directories are written into this directory they are, by default, readable by other users on that same system.

Note: This vulnerability does not allow other users to overwrite the contents of these directories or files. This only affects Unix like systems.

How to fix Information Exposure?

Upgrade junit:junit to version 4.13.1 or higher.

Source: https://security.snyk.io/package/maven/junit:junit/4.12